### PR TITLE
Hotfix on the ban/softban/kick commands.

### DIFF
--- a/Miki/Modules/AdminModule.cs
+++ b/Miki/Modules/AdminModule.cs
@@ -53,6 +53,13 @@ namespace Miki.Modules
                     return;
                 }
 
+                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                {
+                    await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
+                        .SendToChannel(e.Channel);
+                    return;
+                }
+
                 string reason = string.Join(" ", arg);
 
                 IDiscordEmbed embed = Utils.Embed;
@@ -106,6 +113,13 @@ namespace Miki.Modules
                 if (bannedUser.Hierarchy >= e.Guild.CurrentUser.Hierarchy)
                 {
                     await e.ErrorEmbed(e.GetResource("permission_error_low", "softban"))
+                        .SendToChannel(e.Channel);
+                    return;
+                }
+
+                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                {
+                    await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
                         .SendToChannel(e.Channel);
                     return;
                 }
@@ -255,6 +269,13 @@ namespace Miki.Modules
                 if (bannedUser.Hierarchy >= e.Guild.CurrentUser.Hierarchy)
                 {
                     await e.ErrorEmbed(e.GetResource("permission_error_low", "kick"))
+                        .SendToChannel(e.Channel);
+                    return;
+                }
+
+                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                {
+                    await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
                         .SendToChannel(e.Channel);
                     return;
                 }

--- a/Miki/Modules/AdminModule.cs
+++ b/Miki/Modules/AdminModule.cs
@@ -53,7 +53,7 @@ namespace Miki.Modules
                     return;
                 }
 
-                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                if(bannedUser.Hierarchy >= e.Author.Hierarchy)
                 {
                     await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
                         .SendToChannel(e.Channel);
@@ -117,7 +117,7 @@ namespace Miki.Modules
                     return;
                 }
 
-                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                if(bannedUser.Hierarchy >= e.Author.Hierarchy)
                 {
                     await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
                         .SendToChannel(e.Channel);
@@ -273,7 +273,7 @@ namespace Miki.Modules
                     return;
                 }
 
-                if(e.Author.Hierarchy >= bannedUser.Hierarchy)
+                if(bannedUser.Hierarchy >= e.Author.Hierarchy)
                 {
                     await e.ErrorEmbed(e.GetResource("permission_user_error_low", "ban"))
                         .SendToChannel(e.Channel);


### PR DESCRIPTION
Added a check that makes sure that **the user executing** the command(s) has a role above the user who is getting banned/kicked, to users below the role hierarchy from banning anyone above.

This should resolve Issue [#252](https://github.com/Mikibot/Miki/issues/252)