### PR TITLE
Feature - New "showmodules" Command

### DIFF
--- a/Miki/Modules/SettingsModule.cs
+++ b/Miki/Modules/SettingsModule.cs
@@ -145,14 +145,22 @@ namespace Miki.Modules
 
 			modules.Sort();
 
-			string output = "";
+			string firstColumn = "", secondColumn = "";
 
-			foreach( var module in modules )
+			for(int i = 0; i < modules.Count(); i++)
 			{
-				output += $"{( await e.commandHandler.GetModule( module ).IsEnabled( e.Channel.Id ) ? "<:iconenabled:341251534522286080>" : "<:icondisabled:341251533754728458>" )} {module}\n";
+				string output = $"{( await e.commandHandler.GetModule( modules[i] ).IsEnabled( e.Channel.Id ) ? "<:iconenabled:341251534522286080>" : "<:icondisabled:341251533754728458>" )} {modules[i]}\n";
+				if(i < modules.Count() / 2 + 1)
+				{
+					firstColumn += output; 
+				} 
+				else 
+				{
+					secondColumn += output;
+				}
 			}
 
-			await Utils.Embed.SetTitle( $"Module Status for '{e.Channel.Name}'" ).SetDescription( output ).SendToChannel( e.Channel );
+			await Utils.Embed.SetTitle( $"Module Status for '{e.Channel.Name}'" ).AddInlineField( "Column 1", firstColumn ).AddInlineField( "Column 2", secondColumn ).SendToChannel( e.Channel );
 		}
 
         [Command(Name = "setlocale", Accessibility = EventAccessibility.ADMINONLY)]

--- a/Miki/Modules/SettingsModule.cs
+++ b/Miki/Modules/SettingsModule.cs
@@ -8,6 +8,7 @@ using Miki.Languages;
 using Miki.Models;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Miki.Modules
 {
@@ -123,6 +124,36 @@ namespace Miki.Modules
                 await embed.SendToChannel(e.Channel);
             }
         }
+
+		[Command( Name = "showmodules" )]
+		public async Task ShowModulesAsync( EventContext e )
+		{
+			List<string> modules = new List<string>();
+			CommandHandler commandHandler = Bot.instance.Events.CommandHandler;
+			EventAccessibility userEventAccessibility = commandHandler.GetUserAccessibility( e.message );
+
+			foreach( ICommandEvent ev in commandHandler.Commands.Values )
+			{
+				if( userEventAccessibility >= ev.Accessibility )
+				{
+					if( ev.Module != null && !modules.Contains( ev.Module.Name.ToUpper() ) )
+					{
+						modules.Add( ev.Module.Name.ToUpper() );
+					}
+				}
+			}
+
+			modules.Sort();
+
+			string output = "";
+
+			foreach( var module in modules )
+			{
+				output += $"{( await e.commandHandler.GetModule( module ).IsEnabled( e.Channel.Id ) ? "<:iconenabled:341251534522286080>" : "<:icondisabled:341251533754728458>" )} {module}\n";
+			}
+
+			await Utils.Embed.SetTitle( $"Module Status for '{e.Channel.Name}'" ).SetDescription( output ).SendToChannel( e.Channel );
+		}
 
         [Command(Name = "setlocale", Accessibility = EventAccessibility.ADMINONLY)]
         public async Task SetLocale(EventContext e)


### PR DESCRIPTION
#### New command: `>showmodules`
- Aliases: None.
- Description: Will return all of the modules and their status for a channel.
- Usage:
     - `>showmodules <name>`