### PR TITLE
Change to >searchpasta results

### DIFF
--- a/Miki/Modules/PastaModule.cs
+++ b/Miki/Modules/PastaModule.cs
@@ -340,7 +340,7 @@ namespace Miki.Modules
             using (var context = new MikiContext())
             {
                 var pastasFound = await context.Pastas.Where(x => x.Id.ToLower().Contains(query.ToLower()))
-                                                      .OrderByDescending(x => x.Id)
+                                                      .OrderByAscending(x => x.Id)
                                                       .Skip(25 * page)
                                                       .Take(25)
                                                       .ToListAsync();


### PR DESCRIPTION
Changes `>searchpasta` results from displaying in reverse alphabetical order to proper alphabetical order. Seems more user friendly and less confusing.