### PR TITLE
Fix Loved & Hated pastas

### DIFF
--- a/Miki/Modules/PastaModule.cs
+++ b/Miki/Modules/PastaModule.cs
@@ -72,7 +72,7 @@ namespace Miki.Modules
             if (!string.IsNullOrWhiteSpace(e.arguments))
             {
                 List<string> arguments = e.arguments.Split(' ').ToList();
-                if (int.TryParse(arguments[0], out page) || int.TryParse(arguments[0], out page))
+                if (int.TryParse(arguments[0], out page))
                 {
                     page -= 1;
                 }
@@ -394,10 +394,12 @@ namespace Miki.Modules
 				targetUser = await e.Guild.GetUserAsync( e.message.MentionedUserIds.First() );
 				string[] args = e.arguments.Split( ' ' );
 				int.TryParse( (args.Count() > 1 ? args[1] : "0"), out page );
+				page -= page <= 0 ? 0 : 1;
 			}
 			else
 			{
 				int.TryParse( e.arguments, out page );
+				page -= 1;
 			}
 
 			using( MikiContext context = new MikiContext() )
@@ -405,8 +407,10 @@ namespace Miki.Modules
 				long authorId = targetUser.Id.ToDbLong();
 				IEnumerable<PastaVote> pastaVotes = context.Votes.Where( x => x.__UserId == authorId && x.PositiveVote == lovedPastas );
 				
-				int maxPage = (int)Math.Ceiling( pastaVotes.Count() / totalPerPage );
-				page = page > maxPage - 1 ? maxPage - 1 : page;
+				int maxPage = (int)Math.Floor( pastaVotes.Count() / totalPerPage );
+				page = page > maxPage ? maxPage : page;
+				page = page < 0 ? 0 : page;
+				
 
 				if( pastaVotes.Count() <= 0 )
 				{

--- a/Miki/Modules/PastaModule.cs
+++ b/Miki/Modules/PastaModule.cs
@@ -430,7 +430,7 @@ namespace Miki.Modules
 				string resultString = "";
 				neededPastas.ForEach( x => { resultString += "`" + x.Id + "` "; } );
 
-				string useName = string.IsNullOrEmpty( e.Author.Nickname ) ? e.Author.Username : e.Author.Nickname;
+				string useName = string.IsNullOrEmpty( targetUser.Nickname ) ? targetUser.Username : targetUser.Nickname;
 				embed.SetTitle( $"{( lovedPastas ? locale.GetString( "miki_module_pasta_loved_header" ) : locale.GetString( "miki_module_pasta_hated_header" ) )} - {useName}" );
 				embed.SetDescription( resultString );
 				embed.SetFooter( locale.GetString( "page_index", page + 1, Math.Ceiling( pastaVotes.Count() / totalPerPage ) ), "" );


### PR DESCRIPTION
Add a decrement to page number when applicable.
Add check for page being less than zero; if True, set it to the first page.
Change Math.Ceiling() to Math.Floor() in maxPage definition to forgo the `maxPage - 1` when using it.
Change hatedpastas/lovedpastas embed reference from `e.Author` to `targetUser`
Remove weird double comparison in an if statement I committed like 3 months ago.


Fixes #318 & #331 