### PR TITLE
Fix for >guildtop page numbering issue

### DIFF
--- a/Miki/Modules/GuildAccountsModule.cs
+++ b/Miki/Modules/GuildAccountsModule.cs
@@ -274,7 +274,10 @@ namespace Miki.Modules
 
             using (var context = new MikiContext())
             {
-                int totalGuilds = await context.GuildUsers.CountAsync() / 12;
+                int totalGuilds = Ceiling(await context.GuildUsers.CountAsync() / amountToTake);
+                // int totalGuilds = await context.GuildUsers.CountAsync() / 12;
+                // This should ceiling, since when this is corrected going to the last page will be off by 1
+                // Also veld why the fuck was this hardcoded.
 
                 List<GuildUser> leaderboards = await context.GuildUsers.OrderByDescending(x => x.Experience)
                                                                       .Skip(amountToSkip * amountToTake)
@@ -289,7 +292,7 @@ namespace Miki.Modules
                     embed.AddInlineField(i.Name, i.Experience.ToString());
                 }
 
-                embed.SetFooter(e.GetResource("page_index", amountToSkip, totalGuilds), null);
+                embed.SetFooter(e.GetResource("page_index", amountToSkip + 1, totalGuilds), null);
                 await embed.SendToChannel(e.Channel);
             }
         }

--- a/Miki/Modules/GuildAccountsModule.cs
+++ b/Miki/Modules/GuildAccountsModule.cs
@@ -274,10 +274,7 @@ namespace Miki.Modules
 
             using (var context = new MikiContext())
             {
-                int totalGuilds = Ceiling(await context.GuildUsers.CountAsync() / amountToTake);
-                // int totalGuilds = await context.GuildUsers.CountAsync() / 12;
-                // This should ceiling, since when this is corrected going to the last page will be off by 1
-                // Also veld why the fuck was this hardcoded.
+                int totalGuilds = (int) Ceiling((double) await context.GuildUsers.CountAsync() / amountToTake);
 
                 List<GuildUser> leaderboards = await context.GuildUsers.OrderByDescending(x => x.Experience)
                                                                       .Skip(amountToSkip * amountToTake)


### PR DESCRIPTION
Fixed a numbering issue that made page counting start from 0 instead of 1
Replaced hard-coded number with the intended variable

Fixes: #342 