### PR TITLE
Various Pasta Module bugfixes

### DIFF
--- a/Miki/Modules/PastaModule.cs
+++ b/Miki/Modules/PastaModule.cs
@@ -24,10 +24,10 @@ namespace Miki.Modules
     [Module("pasta")]
     public class PastaModule
     {
-		[Configurable]
-		public ulong PastaReportsChannelId { get; set; } = 0;
+        [Configurable]
+        public ulong PastaReportsChannelId { get; set; } = 0;
 
-		[Command(Name = "mypasta")]
+        [Command(Name = "mypasta")]
         public async Task MyPasta(EventContext e)
         {
             int page = 0;
@@ -65,7 +65,7 @@ namespace Miki.Modules
                 if (page * 25 > totalCount)
                 {
                     e.ErrorEmbed(e.Locale.GetString("pasta_error_out_of_index"))
-						.ToEmbed().QueueToChannel(e.Channel);
+                        .ToEmbed().QueueToChannel(e.Channel);
                     return;
                 }
 
@@ -84,34 +84,43 @@ namespace Miki.Modules
                 }
 
                 e.ErrorEmbed(e.Locale.GetString("mypasta_error_no_pastas"))
-					.ToEmbed().QueueToChannel(e.Channel);
+                    .ToEmbed().QueueToChannel(e.Channel);
             }
         }
 
         [Command(Name = "createpasta")]
         public async Task CreatePasta(EventContext e)
         {
-			if (e.Arguments.Count < 2)
+            if (e.Arguments.Count < 2)
             {
                 e.ErrorEmbed(e.Locale.GetString("createpasta_error_no_content"))
-					.ToEmbed().QueueToChannel(e.Channel);
+                    .ToEmbed().QueueToChannel(e.Channel);
                 return;
             }
 
-			ArgObject arg = e.Arguments.FirstOrDefault();
+            ArgObject arg = e.Arguments.FirstOrDefault();
 
-			string id = arg.Argument;
-			arg = arg.Next();
-			string text = arg.TakeUntilEnd().Argument;
+            string id = arg.Argument;
+            arg = arg.Next();
+            string text = arg.TakeUntilEnd().Argument;
 
-			using (var context = new MikiContext())
-			{
-				await GlobalPasta.AddAsync(context, id, text, (long)e.Author.Id);
-				await context.SaveChangesAsync();
-			}
+            using (var context = new MikiContext())
+            {
+                try
+                {
+                    await GlobalPasta.AddAsync(context, id, text, (long)e.Author.Id);
+                    await context.SaveChangesAsync();
+                }
+                catch (DuplicatePastaException e)
+                {
+                    e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_create_error_already_exist", id))
+                        .QueueToChannel(e.Channel);
+                    return;
+                }
+            }
 
-			e.SuccessEmbed(e.Locale.GetString("miki_module_pasta_create_success", id))
-				.QueueToChannel(e.Channel);
+            e.SuccessEmbed(e.Locale.GetString("miki_module_pasta_create_success", id))
+                .ToEmbed().QueueToChannel(e.Channel);
         }
 
         [Command(Name = "deletepasta")]
@@ -119,7 +128,7 @@ namespace Miki.Modules
         {
             if (string.IsNullOrWhiteSpace(e.Arguments.ToString()))
             {
-                e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_specify", e.Locale.GetString("miki_module_pasta_error_specify")))
+                e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_specify", e.Locale.GetString("miki_module_pasta_error_specify_delete")))
                     .ToEmbed().QueueToChannel(e.Channel);
                 return;
             }
@@ -134,9 +143,9 @@ namespace Miki.Modules
                     return;
                 }
 
-				if (pasta.CreatorId == e.Author.Id.ToDbLong())
-				{
-					context.Pastas.Remove(pasta);
+                if (pasta.CreatorId == e.Author.Id.ToDbLong())
+                {
+                    context.Pastas.Remove(pasta);
 
                     List<PastaVote> votes = context.Votes.Where(p => p.Id == e.Arguments.ToString()).ToList();
                     context.Votes.RemoveRange(votes);
@@ -147,7 +156,7 @@ namespace Miki.Modules
                     return;
                 }
                 e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_no_permissions", e.Locale.GetString("miki_module_pasta_error_specify_delete")))
-					.ToEmbed().QueueToChannel(e.Channel);
+                    .ToEmbed().QueueToChannel(e.Channel);
                 return;
             }
         }
@@ -158,16 +167,16 @@ namespace Miki.Modules
             if (e.Arguments.Count < 2)
             {
                 e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_specify", e.Locale.GetString("miki_module_pasta_error_specify_edit")))
-					.ToEmbed().QueueToChannel(e.Channel);
+                    .ToEmbed().QueueToChannel(e.Channel);
                 return;
             }
 
             using (var context = new MikiContext())
             {
-				ArgObject arg = e.Arguments.FirstOrDefault();
+                ArgObject arg = e.Arguments.FirstOrDefault();
 
-				string tag = arg.Argument;
-				arg = arg.Next();
+                string tag = arg.Argument;
+                arg = arg.Next();
 
                 GlobalPasta p = await context.Pastas.FindAsync(tag);
 
@@ -200,7 +209,7 @@ namespace Miki.Modules
                 if (pasta == null)
                 {
                     e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_search_error_no_results", e.Arguments.ToString()))
-						.ToEmbed().QueueToChannel(e.Channel);
+                        .ToEmbed().QueueToChannel(e.Channel);
                     return;
                 }
                 pasta.TimesUsed++;
@@ -212,10 +221,10 @@ namespace Miki.Modules
         [Command(Name = "infopasta")]
         public async Task IdentifyPasta(EventContext e)
         {
-			if (string.IsNullOrWhiteSpace(e.Arguments.ToString()))
+            if (string.IsNullOrWhiteSpace(e.Arguments.ToString()))
             {
                 e.ErrorEmbed(e.Locale.GetString("infopasta_error_no_arg"))
-					.ToEmbed().QueueToChannel(e.Channel);
+                    .ToEmbed().QueueToChannel(e.Channel);
                 return;
             }
 
@@ -256,32 +265,32 @@ namespace Miki.Modules
         [Command(Name = "searchpasta")]
         public async Task SearchPasta(EventContext e)
         {
-			ArgObject arg = e.Arguments.FirstOrDefault();
+            ArgObject arg = e.Arguments.FirstOrDefault();
 
-			if(arg == null)
-			{
-				e.ErrorEmbed(e.Locale.GetString("searchpasta_error_no_arg"))
-					.ToEmbed().QueueToChannel(e.Channel);
-				return;
-			}
+            if(arg == null)
+            {
+                e.ErrorEmbed(e.Locale.GetString("searchpasta_error_no_arg"))
+                    .ToEmbed().QueueToChannel(e.Channel);
+                return;
+            }
 
-			string query = arg.Argument;
+            string query = arg.Argument;
 
-			arg = arg.Next();
+            arg = arg.Next();
 
-			int page = (arg?.AsInt() ?? 0);
+            int page = (arg?.AsInt() ?? 0);
 
             using (var context = new MikiContext())
             {
                 var pastasFound = await context.Pastas.Where(x => x.Id.ToLower().Contains(query.ToLower()))
-					.OrderByDescending(x => x.Id)
-					.Skip(25 * page)
-					.Take(25)
-					.ToListAsync();
+                    .OrderByDescending(x => x.Id)
+                    .Skip(25 * page)
+                    .Take(25)
+                    .ToListAsync();
 
 
                 var totalCount = await context.Pastas.Where(x => x.Id.Contains(query))
-					.CountAsync();
+                    .CountAsync();
 
                 if (pastasFound?.Count > 0)
                 {
@@ -293,7 +302,7 @@ namespace Miki.Modules
                     embed.Title = e.Locale.GetString("miki_module_pasta_search_header");
                     embed.Description = resultString;
 
-					embed.SetFooter(e.Locale.GetString("page_index", page + 1, (Math.Ceiling((double)totalCount / 25)).ToString()));
+                    embed.SetFooter(e.Locale.GetString("page_index", page + 1, (Math.Ceiling((double)totalCount / 25)).ToString()));
 
                     embed.ToEmbed().QueueToChannel(e.Channel);
                     return;
@@ -304,111 +313,111 @@ namespace Miki.Modules
             }
         }
 
-		[Command(Name = "lovedpasta", Aliases = new string[] { "lovedpastas", "favouritepastas", "lovepastalist" })]
-		public async Task LovePastaList(EventContext e)
-		{
-			await FavouritePastaList(e);
-		}
+        [Command(Name = "lovedpasta", Aliases = new string[] { "lovedpastas", "favouritepastas", "lovepastalist" })]
+        public async Task LovePastaList(EventContext e)
+        {
+            await FavouritePastaList(e);
+        }
 
-		[Command(Name = "hatedpasta", Aliases = new string[] { "hatedpastas", "hatepastalist" })]
-		public async Task HatePastaList(EventContext e)
-		{
-			await FavouritePastaList(e, false);
-		}
+        [Command(Name = "hatedpasta", Aliases = new string[] { "hatedpastas", "hatepastalist" })]
+        public async Task HatePastaList(EventContext e)
+        {
+            await FavouritePastaList(e, false);
+        }
 
-		//[Command(Name = "reportpasta")]
-		//public async Task ReportPastaAsync(EventContext e)
-		//{
-		//	ArgObject arg = e.Arguments.FirstOrDefault();
+        //[Command(Name = "reportpasta")]
+        //public async Task ReportPastaAsync(EventContext e)
+        //{
+        //    ArgObject arg = e.Arguments.FirstOrDefault();
 
-		//	if(arg == null)
-		//	{
-		//		// TODO: error message
-		//		return;
-		//	}
+        //    if(arg == null)
+	//    {
+	//        // TODO: error message
+	//        return;
+	//    }
 
-		//	string pastaId = arg.Argument;
-		//	arg = arg.Next();
+	//    string pastaId = arg.Argument;
+	//    arg = arg.Next();
 
-		//	string reason = arg?.TakeUntilEnd()?.Argument ?? "";
+	//    string reason = arg?.TakeUntilEnd()?.Argument ?? "";
 
-		//	if(string.IsNullOrEmpty(reason))
-		//	{
-		//		// TODO: reason empty error
-		//		return;
-		//	}
+	//    if(string.IsNullOrEmpty(reason))
+	//    {
+	//        // TODO: reason empty error
+	//        return;
+	//    }
 
-		//	Utils.SuccessEmbed(e.Channel.Id, "Your report has been received!").QueueToChannel(e.Channel);
+	//    Utils.SuccessEmbed(e.Channel.Id, "Your report has been received!").QueueToChannel(e.Channel);
 
-		//	Utils.Embed.SetAuthor(e.Author.Username, e.Author.GetAvatarUrl(), "")
-		//		.SetDescription($"Reported pasta `{pastaId}`.```{reason}```")
-		//		.SetColor(255, 0 , 0)
-		//		.SetFooter(DateTime.Now.ToString(), "")
-		//		.ToEmbed().QueueToChannel(Bot.Instance.Client.GetChannel(PastaReportsChannelId) as IMessageChannel);
-		//}
+	//    Utils.Embed.SetAuthor(e.Author.Username, e.Author.GetAvatarUrl(), "")
+	//        .SetDescription($"Reported pasta `{pastaId}`.```{reason}```")
+	//        .SetColor(255, 0 , 0)
+	//        .SetFooter(DateTime.Now.ToString(), "")
+	//        .ToEmbed().QueueToChannel(Bot.Instance.Client.GetChannel(PastaReportsChannelId) as IMessageChannel);
+	//}
 
-		public async Task FavouritePastaList(EventContext e, bool lovedPastas = true)
-		{
-			IDiscordUser targetUser = e.Author;
-			float totalPerPage = 25f;
-			int page = 0;
+        public async Task FavouritePastaList(EventContext e, bool lovedPastas = true)
+        {
+            IDiscordUser targetUser = e.Author;
+            float totalPerPage = 25f;
+            int page = 0;
 
-			ArgObject arg = e.Arguments.FirstOrDefault();
+            ArgObject arg = e.Arguments.FirstOrDefault();
 
-			if (arg == null)
-			{
-				// TODO: error no user found
-				return;
-			}
+            if (arg == null)
+            {
+                // TODO: error no user found
+                return;
+            }
 
-			IDiscordUser user = await arg.GetUserAsync(e.Guild);
-			
-			if(user != null)
-			{
-				arg = arg.Next();
-			}
-			else
-			{
-				user = e.Author;
-			}
+            IDiscordUser user = await arg.GetUserAsync(e.Guild);
 
-			page = arg.AsInt() ?? 0;
+            if(user != null)
+            {
+                arg = arg.Next();
+            }
+            else
+            {
+                user = e.Author;
+            }
 
-			using (MikiContext context = new MikiContext())
-			{
-				long authorId = targetUser.Id.ToDbLong();
-				IEnumerable<PastaVote> pastaVotes = context.Votes.Where(x => x.UserId == authorId && x.PositiveVote == lovedPastas);
+            page = arg.AsInt() ?? 0;
 
-				int maxPage = (int)Math.Floor(pastaVotes.Count() / totalPerPage);
-				page = page > maxPage ? maxPage : page;
-				page = page < 0 ? 0 : page;
+            using (MikiContext context = new MikiContext())
+            {
+                long authorId = targetUser.Id.ToDbLong();
+                IEnumerable<PastaVote> pastaVotes = context.Votes.Where(x => x.UserId == authorId && x.PositiveVote == lovedPastas);
+
+                int maxPage = (int)Math.Floor(pastaVotes.Count() / totalPerPage);
+                page = page > maxPage ? maxPage : page;
+                page = page < 0 ? 0 : page;
 
 
-				if (pastaVotes.Count() <= 0)
-				{
-					string loveString = (lovedPastas ? e.Locale.GetString("miki_module_pasta_loved") : e.Locale.GetString("miki_module_pasta_hated"));
-					string errorString = e.Locale.GetString("miki_module_pasta_favlist_self_none", loveString);
-					if (e.message.MentionedUserIds.Count() >= 1)
-					{
-						errorString = e.Locale.GetString("miki_module_pasta_favlist_mention_none", loveString);
-					}
-					Utils.ErrorEmbed(e, errorString).ToEmbed().QueueToChannel(e.Channel);
-					return;
-				}
+                if (pastaVotes.Count() <= 0)
+                {
+                    string loveString = (lovedPastas ? e.Locale.GetString("miki_module_pasta_loved") : e.Locale.GetString("miki_module_pasta_hated"));
+                    string errorString = e.Locale.GetString("miki_module_pasta_favlist_self_none", loveString);
+                    if (e.message.MentionedUserIds.Count() >= 1)
+                    {
+                        errorString = e.Locale.GetString("miki_module_pasta_favlist_mention_none", loveString);
+                    }
+                    Utils.ErrorEmbed(e, errorString).ToEmbed().QueueToChannel(e.Channel);
+                    return;
+                }
 
-				EmbedBuilder embed = Utils.Embed;
-				List<PastaVote> neededPastas = pastaVotes.Skip((int)totalPerPage * page).Take((int)totalPerPage).ToList();
+                EmbedBuilder embed = Utils.Embed;
+                List<PastaVote> neededPastas = pastaVotes.Skip((int)totalPerPage * page).Take((int)totalPerPage).ToList();
 
-				string resultString = string.Join(" ", neededPastas.Select(x => $"`{x.Id}`"));
+                string resultString = string.Join(" ", neededPastas.Select(x => $"`{x.Id}`"));
 
-				string useName = string.IsNullOrEmpty(targetUser.Username) ? targetUser.Username : targetUser.Username;
-				embed.SetTitle($"{(lovedPastas ? e.Locale.GetString("miki_module_pasta_loved_header") : e.Locale.GetString("miki_module_pasta_hated_header"))} - {useName}");
-				embed.SetDescription(resultString);
-				embed.SetFooter(e.Locale.GetString("page_index", page + 1, Math.Ceiling(pastaVotes.Count() / totalPerPage)), "");
+                string useName = string.IsNullOrEmpty(targetUser.Username) ? targetUser.Username : targetUser.Username;
+                embed.SetTitle($"{(lovedPastas ? e.Locale.GetString("miki_module_pasta_loved_header") : e.Locale.GetString("miki_module_pasta_hated_header"))} - {useName}");
+                embed.SetDescription(resultString);
+                embed.SetFooter(e.Locale.GetString("page_index", page + 1, Math.Ceiling(pastaVotes.Count() / totalPerPage)), "");
 
-				embed.ToEmbed().QueueToChannel(e.Channel);
-			}
-		}
+                embed.ToEmbed().QueueToChannel(e.Channel);
+            }
+        }
 
         [Command(Name = "lovepasta")]
         public async Task LovePasta(EventContext e)
@@ -422,49 +431,49 @@ namespace Miki.Modules
             await VotePasta(e, false);
         }
 
-		private async Task VotePasta(EventContext e, bool vote)
-		{
-			string pastaName = e.Arguments.First().Argument;
+        private async Task VotePasta(EventContext e, bool vote)
+        {
+            string pastaName = e.Arguments.First().Argument;
 
-			using (var context = new MikiContext())
-			{
-				var pasta = await context.Pastas.FindAsync(pastaName);
+            using (var context = new MikiContext())
+            {
+                var pasta = await context.Pastas.FindAsync(pastaName);
 
-				if (pasta == null)
-				{
-					e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_null")).ToEmbed().QueueToChannel(e.Channel);
-					return;
-				}
+                if (pasta == null)
+                {
+                    e.ErrorEmbed(e.Locale.GetString("miki_module_pasta_error_null")).ToEmbed().QueueToChannel(e.Channel);
+                    return;
+                }
 
-				long authorId = e.Author.Id.ToDbLong();
+                long authorId = e.Author.Id.ToDbLong();
 
-				var voteObject = context.Votes
-					.Where(q => q.Id == pastaName && q.UserId == authorId)
-					.FirstOrDefault();
+                var voteObject = context.Votes
+                    .Where(q => q.Id == pastaName && q.UserId == authorId)
+                    .FirstOrDefault();
 
-				if (voteObject == null)
-				{
-					voteObject = new PastaVote()
-					{
-						Id = pastaName, UserId = e.Author.Id.ToDbLong(), PositiveVote = vote
-					};
+                if (voteObject == null)
+                {
+                    voteObject = new PastaVote()
+                    {
+                        Id = pastaName, UserId = e.Author.Id.ToDbLong(), PositiveVote = vote
+                    };
 
-					context.Votes.Add(voteObject);
-				}
-				else
-				{
-					voteObject.PositiveVote = vote;
-				}
+                    context.Votes.Add(voteObject);
+                }
+                else
+                {
+                    voteObject.PositiveVote = vote;
+                }
 
-				await context.SaveChangesAsync();
+                await context.SaveChangesAsync();
 
-				var votecount = await pasta.GetVotesAsync(context);
-				pasta.Score = votecount.Upvotes - votecount.Downvotes;
+                var votecount = await pasta.GetVotesAsync(context);
+                pasta.Score = votecount.Upvotes - votecount.Downvotes;
 
-				await context.SaveChangesAsync();
+                await context.SaveChangesAsync();
 
-				e.SuccessEmbed(e.Locale.GetString("miki_module_pasta_vote_success", votecount.Upvotes - votecount.Downvotes)).QueueToChannel(e.Channel);
-			}
+                e.SuccessEmbed(e.Locale.GetString("miki_module_pasta_vote_success", votecount.Upvotes - votecount.Downvotes)).QueueToChannel(e.Channel);
+            }
         }
     }
 }


### PR DESCRIPTION
Added try/catch in `createpasta` to fix silent failure when attempting to overwrite an existing pasta.

Fixed `deletepasta` asking you to "Please specify which pasta you would like to Please specify which pasta you would like to {0}.." It should now properly read "Please specify which pasta you would like to delete."



Also 4 spaces > tabs.
You can't change my mind.