### PR TITLE
Recalibrate slot machine weights and payouts

### DIFF
--- a/Miki/Modules/Gambling/GamesModule.cs
+++ b/Miki/Modules/Gambling/GamesModule.cs
@@ -487,18 +487,13 @@ namespace Miki.Modules
 
 				string[] objects =
 				{
-					"🍒", "🍒", "🍒", "🍒",
-					"🍊", "🍊", "🍊",
-					"🍓", "🍓",
-					"🍍", "🍍",
-					"🍇", "🍇",
+					"🍒", "🍒", "🍒", "🍒", "🍒", "🍒", "🍒",
+					"🍊", "🍊", "🍊", "🍊", "🍊", "🍊",
+					"🍓", "🍓", "🍓", "🍓", "🍓",
+					"🍍", "🍍", "🍍", "🍍",
+					"🍇", "🍇", "🍇",
 					"🍉", "🍉",
-					"⭐", "⭐",
-					"🍉",
-					"🍍", "🍍",
-					"🍓", "🍓",
-					"🍊", "🍊", "🍊",
-					"🍒", "🍒", "🍒", "🍒",
+					"⭐",
 				};
 
 				EmbedBuilder embed = new EmbedBuilder()
@@ -527,33 +522,33 @@ namespace Miki.Modules
 				{
 					if (score["🍒"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 0.5f);
+						moneyReturned = (int)Math.Ceiling(bet * 0.25f);
 					}
 					else if (score["🍒"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 1f);
+						moneyReturned = (int)Math.Ceiling(bet * 3f);
 					}
 				}
 				if (score.ContainsKey("🍊"))
 				{
 					if (score["🍊"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 0.8f);
+						moneyReturned = (int)Math.Ceiling(bet * 0.5f);
 					}
 					else if (score["🍊"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 1.5f);
+						moneyReturned = (int)Math.Ceiling(bet * 5f);
 					}
 				}
 				if (score.ContainsKey("🍓"))
 				{
 					if (score["🍓"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 1f);
+						moneyReturned = (int)Math.Ceiling(bet * 0.75f);
 					}
 					else if (score["🍓"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 2f);
+						moneyReturned = (int)Math.Ceiling(bet * 7f);
 					}
 				}
 				if (score.ContainsKey("🍍"))
@@ -564,40 +559,40 @@ namespace Miki.Modules
 					}
 					if (score["🍍"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 4f);
+						moneyReturned = (int)Math.Ceiling(bet * 10f);
 					}
 				}
 				if (score.ContainsKey("🍇"))
 				{
 					if (score["🍇"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 1.2f);
+						moneyReturned = (int)Math.Ceiling(bet * 2f);
 					}
 					if (score["🍇"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 6f);
+						moneyReturned = (int)Math.Ceiling(bet * 15f);
 					}
 				}
 				if (score.ContainsKey("🍉"))
 				{
 					if (score["🍉"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 1.5f);
+						moneyReturned = (int)Math.Ceiling(bet * 3f);
 					}
 					if (score["🍉"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 10f);
+						moneyReturned = (int)Math.Ceiling(bet * 25f);
 					}
 				}
 				if (score.ContainsKey("⭐"))
 				{
 					if (score["⭐"] == 2)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 2f);
+						moneyReturned = (int)Math.Ceiling(bet * 7f);
 					}
 					if (score["⭐"] == 3)
 					{
-						moneyReturned = (int)Math.Ceiling(bet * 12f);
+						moneyReturned = (int)Math.Ceiling(bet * 75f);
 
 						await AchievementManager.Instance.GetContainerById("slots").CheckAsync(new BasePacket()
 						{


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1EtCriaFtdi0J_dGmvASuhxvGXeWYnYzx2ZaPAU5dM34/edit#gid=274012695
(Taken from the Better Experimental Tab)
Here, I've demonstrated how weights and payouts contribute to the overall dollar returned per dollar bet. At the present moment, players get 0.873 dollars per dollar spent, which is waaay off ideal.
In order for a slot machine to feel "fun," each possible win has to be scaled with how hard it is to achieve-- otherwise, players feel under-rewarded. With the new calibration values, the weights of the fruits scale linearly, allowing the probabilities to scale exponentially, with rewards that are equal to sqrt(probability)/probability, in order to make payouts seem as fair as possible while still ensuring that players don't get constantly screwed over because of a heavy jackpot skewing the scale.
Listen I did the math okay this is the change you want. You can double-check the spreadsheet yourself.