### PR TITLE
Allow Miki to boot up with only a token (and db)

### DIFF
--- a/src/Miki/Miki.csproj
+++ b/src/Miki/Miki.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="Miki.Anilist" Version="0.6.1" />
     <PackageReference Include="Miki.BunnyCDN" Version="0.1.0" />
+    <PackageReference Include="Miki.Cache.InMemory" Version="1.3.0" />
     <PackageReference Include="Miki.Cache.StackExchange.Redis" Version="2.3.0" />
     <PackageReference Include="Miki.Configuration" Version="1.0.0" />
     <PackageReference Include="Miki.Configuration.Providers.Json" Version="1.0.1" />

--- a/src/Miki/Modules/Internal/Routines/DatadogService.cs
+++ b/src/Miki/Modules/Internal/Routines/DatadogService.cs
@@ -25,6 +25,12 @@
             IDiscordClient discordClient,
             DiscordApiClient discordApiClient)
         {
+            if(string.IsNullOrWhiteSpace(config.DatadogHost))
+            {
+                Log.Warning("Metrics are not being collected");
+                return;
+            }
+
             DogStatsd.Configure(new StatsdConfig
             {
                 // TODO #534: Change to [Configurable]


### PR DESCRIPTION
- Self-host mode now uses InMemoryCacheClient, meaning Redis is no longer needed.
- DatadogRoutine will not apply any events if an invalid data aggregator ip is given.