### PR TITLE
Fixed arguments in custom commands

### DIFF
--- a/src/Miki/Modules/CustomCommands/Services/CustomCommandsService.cs
+++ b/src/Miki/Modules/CustomCommands/Services/CustomCommandsService.cs
@@ -387,7 +387,7 @@ namespace Miki.Modules.CustomCommands.Services
             {
                 string value;
 
-                if (Mention.TryParse(str, out var mention))
+                if (!string.IsNullOrEmpty(str) && str[0] == '<' && Mention.TryParse(str, out var mention))
                 {
                     value = mention.Type switch
                     {


### PR DESCRIPTION
Mention.TryParse throws an exception when the character starts with the letter 'a'. It doesn't validate if the string starts with a '<', so it throws an index out of range exception. This needs to be fixed in ~~Miki.Framework~~ Miki.Discord but for now this is a work-around.