### PR TITLE
Fixed custom command arguments

### DIFF
--- a/src/Miki/Miki.csproj
+++ b/src/Miki/Miki.csproj
@@ -50,8 +50,8 @@
     <PackageReference Include="Miki.Functional.Async" Version="0.0.1" />
     <PackageReference Include="Miki.Serialization.Protobuf" Version="1.0.4" />
     <PackageReference Include="Miki.UrbanDictionary" Version="0.2.0" />
-    <PackageReference Include="MiScript.Compiler" Version="4.0.1-pre.20200706.13" />
-    <PackageReference Include="MiScript.Runtime" Version="4.0.1-pre.20200706.13" />
+    <PackageReference Include="MiScript.Compiler" Version="4.0.1-pre.20200708.4" />
+    <PackageReference Include="MiScript.Runtime" Version="4.0.1-pre.20200708.4" />
     <PackageReference Include="NCalc.NetCore" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />

--- a/src/Miki/Modules/CustomCommands/Services/CustomCommandsService.cs
+++ b/src/Miki/Modules/CustomCommands/Services/CustomCommandsService.cs
@@ -260,7 +260,7 @@ namespace Miki.Modules.CustomCommands.Services
             if (!isDonator.HasValue)
             {
                 var userService = e.GetService<IUserService>();
-                isDonator = await userService.UserIsDonatorAsync(guildId);
+                isDonator = await userService.UserIsDonatorAsync((long) guild.OwnerId);
             }
             
             var keyLimit = isDonator.Value ? DonatorKeyLimit : KeyLimit;
@@ -381,7 +381,7 @@ namespace Miki.Modules.CustomCommands.Services
 
             var guild = e.GetGuild();
 
-            e.GetArgumentPack().Skip();
+            argumentPack.Pack.SetCursor(1);
 
             while (argumentPack.Take<string>(out var str))
             {


### PR DESCRIPTION
Creating a custom command that is a module name (e.g. `actions` or `nsfw`) would skip the first argument.

Example: 
![image](https://user-images.githubusercontent.com/2109929/86958518-98077900-c15c-11ea-8a47-25729bac885f.png)

And fixed the wrong ID being used, this was only an issue in eval.